### PR TITLE
すり抜け床の秒数指定、すり抜け床の上で弾が消えるバグ修正

### DIFF
--- a/MicroMacro/Assets/Prefabs/General/Through Floor.prefab
+++ b/MicroMacro/Assets/Prefabs/General/Through Floor.prefab
@@ -247,8 +247,9 @@ MonoBehaviour:
   aroundTrigger: {fileID: 8448404558159733377}
   objectTrigger: {fileID: 4871039023400974943}
   inputDirection: 1
-  isCompleteThrough: 1
+  isCompleteThrough: 0
   isOneWay: 0
+  requiredInputTime: 0.15
 --- !u!1 &7394916958190040015
 GameObject:
   m_ObjectHideFlags: 0
@@ -262,7 +263,7 @@ GameObject:
   - component: {fileID: 5590503857997102484}
   - component: {fileID: 7884518121269138573}
   - component: {fileID: 8448404558159733377}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Top Trigger
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/MicroMacro/Assets/Prefabs/General/Through Floor_1-1-1.prefab
+++ b/MicroMacro/Assets/Prefabs/General/Through Floor_1-1-1.prefab
@@ -126,8 +126,9 @@ MonoBehaviour:
   aroundTrigger: {fileID: 7528587087901179372}
   objectTrigger: {fileID: 724616338048050487}
   inputDirection: 1
-  isCompleteThrough: 1
+  isCompleteThrough: 0
   isOneWay: 0
+  requiredInputTime: 0.15
 --- !u!1 &6529033081446956332
 GameObject:
   m_ObjectHideFlags: 0
@@ -141,7 +142,7 @@ GameObject:
   - component: {fileID: 4348695256309488417}
   - component: {fileID: 9173668577633896840}
   - component: {fileID: 7528587087901179372}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Top Trigger
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/MicroMacro/Assets/Prefabs/General/Through Floor_1-1-2.prefab
+++ b/MicroMacro/Assets/Prefabs/General/Through Floor_1-1-2.prefab
@@ -247,8 +247,9 @@ MonoBehaviour:
   aroundTrigger: {fileID: 2438388008647932054}
   objectTrigger: {fileID: 3182779251676809336}
   inputDirection: 1
-  isCompleteThrough: 1
+  isCompleteThrough: 0
   isOneWay: 0
+  requiredInputTime: 0.15
 --- !u!1 &4747784165814649376
 GameObject:
   m_ObjectHideFlags: 0

--- a/MicroMacro/Assets/Prefabs/General/Through Floor_1-1-3.prefab
+++ b/MicroMacro/Assets/Prefabs/General/Through Floor_1-1-3.prefab
@@ -247,8 +247,9 @@ MonoBehaviour:
   aroundTrigger: {fileID: 2982161059406503153}
   objectTrigger: {fileID: 2404916765203702562}
   inputDirection: 1
-  isCompleteThrough: 1
+  isCompleteThrough: 0
   isOneWay: 0
+  requiredInputTime: 0.15
 --- !u!1 &8967453534467063563
 GameObject:
   m_ObjectHideFlags: 0
@@ -262,7 +263,7 @@ GameObject:
   - component: {fileID: 5475789587856176319}
   - component: {fileID: 4042125996746832519}
   - component: {fileID: 2982161059406503153}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Top Trigger
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/MicroMacro/Assets/Prefabs/General/Through Floor_Cube.prefab
+++ b/MicroMacro/Assets/Prefabs/General/Through Floor_Cube.prefab
@@ -134,7 +134,7 @@ GameObject:
   - component: {fileID: 5550407325077527325}
   - component: {fileID: 955456707611014657}
   - component: {fileID: 4794457355501068015}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Top Trigger
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -368,5 +368,6 @@ MonoBehaviour:
   aroundTrigger: {fileID: 4794457355501068015}
   objectTrigger: {fileID: 2843490323476407718}
   inputDirection: 1
-  isCompleteThrough: 1
+  isCompleteThrough: 0
   isOneWay: 0
+  requiredInputTime: 0.15

--- a/MicroMacro/Assets/Scripts/Module/Gimmick/ThroughPlatform.cs
+++ b/MicroMacro/Assets/Scripts/Module/Gimmick/ThroughPlatform.cs
@@ -25,7 +25,13 @@ namespace Module.Gimmick
         
         [Header("一方通行にするか")]
         [SerializeField] private bool isOneWay = false;
-        private Vector2 direction;
+        
+        [Header("すり抜けるための入力時間")]
+        [Tooltip("ここで設定した秒数だけ指定方向に入力し続けると、床を貫通してすり抜けます。")]
+        [SerializeField] private float requiredInputTime = 0.25f;
+        
+        private float inputTimer;
+        private Vector2 requiredDirection;
         private PlayerCondition condition;
 
         private void Start() => Initialize();
@@ -41,7 +47,7 @@ namespace Module.Gimmick
                 objectTrigger.OnTriggerChanged += StatusCheck;
             
             // switch文を簡略化したswitch式
-            direction = inputDirection switch
+            requiredDirection = inputDirection switch
             {
                 Direction.Up => Vector2.up,
                 Direction.Down => Vector2.down,
@@ -75,7 +81,7 @@ namespace Module.Gimmick
             
             // WARNING: Triggerを大きくしすぎると、下入力しながら落下->Triggerに入ってから離す、ですり抜けが出来てしまう可能性あり。
             // 引っ掛からずにすり抜けも可能に
-            if (condition.Direction == direction && isCompleteThrough)
+            if (condition.Direction == requiredDirection && isCompleteThrough)
                 return;
             
             if (aroundTrigger.IsTriggered && !objectTrigger.IsTriggered) 
@@ -90,11 +96,32 @@ namespace Module.Gimmick
             if (isOneWay || condition == null)
                 return;
             
-            // 下入力で降りる
             if (collision.gameObject.CompareTag(Tag.Handle.Player))
             {
-                if (condition.Direction == direction) 
-                    SwitchPlatformLayer(false);
+                // 指定方向の入力がある場合
+                if (condition.Direction == requiredDirection)
+                {
+                    inputTimer += Time.deltaTime;
+
+                    if (inputTimer >= requiredInputTime)
+                    {
+                        SwitchPlatformLayer(false);
+                        inputTimer = 0f;
+                    }
+                }
+                else
+                {
+                    inputTimer = 0f;
+                }
+            }
+        }
+        
+        private void OnCollisionExit(Collision collision)
+        {
+            // 離れたらリセット
+            if (collision.gameObject.CompareTag(Tag.Handle.Player))
+            {
+                inputTimer = 0f;
             }
         }
     }


### PR DESCRIPTION

- デフォルトですり抜け床は指定秒数下入力しないとすり抜けないようにしました。
一応引っかからずにすり抜ける機能も切り替えできるように残してある。
- すり抜け床の上で弾を撃つと消える不具合の修正。