### PR TITLE
フェードシステム改善

### DIFF
--- a/MicroMacro/Assets/Prefabs/System/FadeImage.prefab
+++ b/MicroMacro/Assets/Prefabs/System/FadeImage.prefab
@@ -53,7 +53,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4521264754793471549}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
@@ -89,4 +89,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   firstFadeInComp: 0
-  FadeDuration: 1.5
+  fadeDuration: 1.5

--- a/MicroMacro/Assets/Prefabs/System/SceneManager.prefab
+++ b/MicroMacro/Assets/Prefabs/System/SceneManager.prefab
@@ -45,7 +45,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6147e172d9bd42d9a7b7d3132cfb54dc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  fadeHandler: {fileID: 0}
+  fadeCanvasPrefab: {fileID: 5820637988478227065, guid: 689836e242958fd4e85cf817fe47fdf2, type: 3}
   nextSceneName: Boss
 --- !u!114 &7788081593894957190
 MonoBehaviour:

--- a/MicroMacro/Assets/Prefabs/UI/FadeCanvas.prefab
+++ b/MicroMacro/Assets/Prefabs/UI/FadeCanvas.prefab
@@ -1,0 +1,210 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5820637988478227065
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 556973462196918010}
+  - component: {fileID: 6576939523693628141}
+  - component: {fileID: 4878609334430967069}
+  - component: {fileID: 920415915283996978}
+  m_Layer: 5
+  m_Name: FadeCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &556973462196918010
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5820637988478227065}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4011788692734476625}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &6576939523693628141
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5820637988478227065}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &4878609334430967069
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5820637988478227065}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &920415915283996978
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5820637988478227065}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1001 &7634841429029929936
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 556973462196918010}
+    m_Modifications:
+    - target: {fileID: 4521264754793471549, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_Name
+      value: FadeImage
+      objectReference: {fileID: 0}
+    - target: {fileID: 4521264754793471549, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1920
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1080
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+--- !u!224 &4011788692734476625 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6798424823914414721, guid: e012c3cdbb2e27443bf6fe48debe733b, type: 3}
+  m_PrefabInstance: {fileID: 7634841429029929936}
+  m_PrefabAsset: {fileID: 0}

--- a/MicroMacro/Assets/Prefabs/UI/FadeCanvas.prefab
+++ b/MicroMacro/Assets/Prefabs/UI/FadeCanvas.prefab
@@ -60,7 +60,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 0
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 10
   m_TargetDisplay: 0
 --- !u!114 &4878609334430967069
 MonoBehaviour:

--- a/MicroMacro/Assets/Prefabs/UI/FadeCanvas.prefab.meta
+++ b/MicroMacro/Assets/Prefabs/UI/FadeCanvas.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 689836e242958fd4e85cf817fe47fdf2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/FadeAndSceneTransition.cs
+++ b/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/FadeAndSceneTransition.cs
@@ -1,71 +1,122 @@
 ﻿using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityEngine.Serialization;
 
 namespace Module.Application.SceneSwitch
 {
     public class FadeAndSceneTransition : MonoBehaviour
     {
-        [Header("フェード処理")] public GameObject faderObj;
-        [Header("移動するシーンの名前")] public string nextSceneName;
+        [Header("フェードCanvasのPrefab")]
+        [SerializeField] GameObject fadeCanvasPrefab;
+        [Header("移動するシーンの名前")]
+        public string nextSceneName;
 
-        private IFadeHandler fader;
-        private bool isSceneTransitioning = false;
+        private static GameObject faderObj;
+        private static IFadeHandler fadeHandler;
+        private bool isSceneTransitioning;
 
-        private void Start()
+        private void Awake()
         {
-            // fadeHandlerがIFadeHandlerを実装していればIFadeHandler型に変換して代入
-            fader = faderObj.GetComponent<IFadeHandler>();
-
-            if (fader == null)
+            if (faderObj == null)
             {
-                Debug.LogError("IFadeHandlerがアタッチされていません: " + faderObj);
+                CreateAndRegisterFader();
+            }
+        }
+
+        private void OnEnable()
+        {
+            SceneManager.sceneLoaded += OnSceneLoaded;
+        }
+
+        private void OnDisable()
+        {
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+        }
+
+        /// <summary>
+        /// FadeCanvasの生成、永続化
+        /// </summary>
+        private void CreateAndRegisterFader()
+        {
+            if (fadeCanvasPrefab == null)
+            {
+                fadeCanvasPrefab = Resources.Load<GameObject>("FadeCanvas");
+            }
+            
+            if (fadeCanvasPrefab == null)
+            {
+                Debug.LogError("FadeCanvasが見つかりません"); 
+                return;
+            }
+
+            faderObj = Instantiate(fadeCanvasPrefab);
+            DontDestroyOnLoad(faderObj);
+
+            // faderがIFadeHandlerを実装していればIFadeHandler型に変換して代入
+            fadeHandler = faderObj.GetComponentInChildren<IFadeHandler>();
+            if (fadeHandler == null)
+            {
+                Debug.LogError("FadeCanvasにIFadeHandler実装がありません");
             }
         }
 
         /// <summary>
-        /// 遷移の開始 余計な音を止める->フェードアウト->シーン遷移
+        /// シーン切り替え開始（フェードアウト → ロード → フェードイン）
         /// </summary>
         public void StartTransition()
         {
-            if (isSceneTransitioning || fader == null)
+            if (isSceneTransitioning || fadeHandler == null)
                 return;
 
             if (string.IsNullOrEmpty(nextSceneName) || nextSceneName == SceneManager.GetActiveScene().name)
             {
-                Debug.LogError("nextSceneNameが設定されていないか、現在のシーンと同じです");
+                Debug.LogError("次のシーン名が設定されていないか、現在のシーンと同じです");
                 return;
             }
 
             isSceneTransitioning = true;
 
-            //余計なサウンド停止 
+            // サウンド停止等あれば
             // SoundManager.instance.StopAllSound();
 
-            fader.StartFadeOut();
+            fadeHandler.StartFadeOut();
             StartCoroutine(LoadNextSceneAsync());
         }
 
         /// <summary>
-        /// 名前指定してシーン移動
+        /// 名前指定してシーン移動したい場合
         /// </summary>
-        /// <param name="nextSceneName"></param>
-        public void StartTransition(string nextSceneName)
+        public void StartTransition(string SceneName)
         {
-            this.nextSceneName = nextSceneName;
+            nextSceneName = SceneName;
             StartTransition();
         }
 
+        /// <summary>
+        /// フェードアウト完了を待ってシーンを非同期ロード
+        /// </summary>
         private IEnumerator LoadNextSceneAsync()
         {
-            while (fader.IsFadeOutComplete() == false)
+            // 同時に呼ばれたUpdateを反映させるため1フレ待機 (多分)
+            yield return null;
+
+            while (fadeHandler.IsFadeOutComplete() == false)
             {
                 yield return null;
             }
 
-            // LoadSceneMode.Singleは現在のシーンを自動アンロード
-            SceneManager.LoadSceneAsync(nextSceneName, LoadSceneMode.Single);
+            // LoadSceneMode.Singleは現在のシーンを自動アンロードしてくれる
+            yield return SceneManager.LoadSceneAsync(nextSceneName, LoadSceneMode.Single);
+        }
+
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            if (fadeHandler != null)
+            {
+                fadeHandler.StartFadeIn();
+            }
+
+            isSceneTransitioning = false;
         }
     }
 }

--- a/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/FadeAndSceneTransition.cs
+++ b/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/FadeAndSceneTransition.cs
@@ -59,7 +59,7 @@ namespace Module.Application.SceneSwitch
 
         private IEnumerator LoadNextSceneAsync()
         {
-            while (fader.IsFadeOutComplete())
+            while (fader.IsFadeOutComplete() == false)
             {
                 yield return null;
             }

--- a/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/FadeAndSceneTransition.cs
+++ b/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/FadeAndSceneTransition.cs
@@ -1,28 +1,27 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using UnityEngine.Serialization;
 
 namespace Module.Application.SceneSwitch
 {
     public class FadeAndSceneTransition : MonoBehaviour
     {
-        [Header("フェード処理")] public GameObject fadeHandler;
+        [Header("フェード処理")] public GameObject faderObj;
         [Header("移動するシーンの名前")] public string nextSceneName;
 
-        private IFadeHandler m_fade;
+        private IFadeHandler fader;
         private bool isSceneTransitioning = false;
 
         private void Start()
         {
             // fadeHandlerがIFadeHandlerを実装していればIFadeHandler型に変換して代入
-            m_fade = fadeHandler.GetComponent<IFadeHandler>();
+            fader = faderObj.GetComponent<IFadeHandler>();
 
-            if (m_fade == null)
+            if (fader == null)
             {
-                Debug.LogError("No IFadeHandler attached to fadeHandler");
+                Debug.LogError("IFadeHandlerがアタッチされていません: " + faderObj);
             }
-            
         }
 
         /// <summary>
@@ -30,12 +29,12 @@ namespace Module.Application.SceneSwitch
         /// </summary>
         public void StartTransition()
         {
-            if (isSceneTransitioning || m_fade == null)
+            if (isSceneTransitioning || fader == null)
                 return;
 
-            if (nextSceneName == SceneManager.GetActiveScene().name)
+            if (string.IsNullOrEmpty(nextSceneName) || nextSceneName == SceneManager.GetActiveScene().name)
             {
-                Debug.LogError("nextSceneNameと現在アクティブなシーンが同じです");
+                Debug.LogError("nextSceneNameが設定されていないか、現在のシーンと同じです");
                 return;
             }
 
@@ -44,7 +43,7 @@ namespace Module.Application.SceneSwitch
             //余計なサウンド停止 
             // SoundManager.instance.StopAllSound();
 
-            m_fade.StartFadeOut();
+            fader.StartFadeOut();
             StartCoroutine(LoadNextSceneAsync());
         }
 
@@ -60,14 +59,13 @@ namespace Module.Application.SceneSwitch
 
         private IEnumerator LoadNextSceneAsync()
         {
-            while (m_fade.IsFadeOutComplete() == false)
+            while (fader.IsFadeOutComplete())
             {
                 yield return null;
             }
 
+            // LoadSceneMode.Singleは現在のシーンを自動アンロード
             SceneManager.LoadSceneAsync(nextSceneName, LoadSceneMode.Single);
-
-            yield return SceneManager.UnloadSceneAsync(SceneManager.GetActiveScene());
         }
     }
 }

--- a/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/FadeAndSceneTransition.cs
+++ b/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/FadeAndSceneTransition.cs
@@ -40,12 +40,7 @@ namespace Module.Application.SceneSwitch
         {
             if (fadeCanvasPrefab == null)
             {
-                fadeCanvasPrefab = Resources.Load<GameObject>("FadeCanvas");
-            }
-            
-            if (fadeCanvasPrefab == null)
-            {
-                Debug.LogError("FadeCanvasが見つかりません"); 
+                Debug.LogError("FadeCanvasがアタッチされていません"); 
                 return;
             }
 

--- a/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/IFadeHandler.cs
+++ b/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/IFadeHandler.cs
@@ -4,5 +4,6 @@
     {
         void StartFadeOut();        // フェードアウトを開始する
         bool IsFadeOutComplete();   // フェードアウトが完了したかを確認する
+        bool IsFading();
     }
 }

--- a/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/IFadeHandler.cs
+++ b/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/IFadeHandler.cs
@@ -2,8 +2,9 @@
 {
     public interface IFadeHandler
     {
-        void StartFadeOut();        // フェードアウトを開始する
-        bool IsFadeOutComplete();   // フェードアウトが完了したかを確認する
+        void StartFadeOut();        
+        void StartFadeIn();
+        bool IsFadeOutComplete();   
         bool IsFading();
     }
 }

--- a/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/ImageFader.cs
+++ b/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/ImageFader.cs
@@ -31,7 +31,7 @@ namespace Module.Application.SceneSwitch
 
             if (firstFadeInComp)
             {
-                FadeInComplete();
+                OnFadeInComplete();
             }
             else
             {
@@ -44,12 +44,12 @@ namespace Module.Application.SceneSwitch
             if (fadeState == FadeState.FadingIn)
             {
                 // タイマーが進むにつれα値が1から0に(透明に)
-                UpdateFade(1 - GetFadeProgress(), FadeInComplete);
+                UpdateFade(1 - GetFadeProgress(), OnFadeInComplete);
             }
             else if (fadeState == FadeState.FadingOut)
             {
                 // タイマーが進むにつれα値が0から1に(暗く)
-                UpdateFade(GetFadeProgress(), FadeOutComplete);
+                UpdateFade(GetFadeProgress(), OnFadeOutComplete);
             }
         }
        
@@ -78,9 +78,11 @@ namespace Module.Application.SceneSwitch
                 // フェードイン中にフェードアウトが呼ばれた場合、
                 // 進行度を引き継いでスムーズに移行
                 timer = FadeDuration - timer;
+                Debug.Log("time = " + timer);
             }
             else
             {
+                Debug.Log("call reset Timer");
                 ResetTimer();
                 SetImageProperties(0,true);
             }
@@ -116,24 +118,26 @@ namespace Module.Application.SceneSwitch
         /// <param name="alpha">進捗</param>
         private void UpdateFade(float alpha, System.Action onComplete)
         {
+            Debug.Log(timer);
             // α値を更新
             img.color = new Color(img.color.r, img.color.g, img.color.b, alpha);
 
             if (timer >= FadeDuration)
             {
+                Debug.Log($"OnComplete {timer} : " + FadeDuration);
                 onComplete?.Invoke();
             }
 
             timer += Time.deltaTime;
         }
    
-        private void FadeInComplete()
+        private void OnFadeInComplete()
         {
             SetImageProperties(0,  false);
             fadeState = FadeState.None;
         }
         
-        private void FadeOutComplete()
+        private void OnFadeOutComplete()
         {
             SetImageProperties(1,  false);
             fadeState = FadeState.None;

--- a/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/ImageFader.cs
+++ b/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/ImageFader.cs
@@ -25,7 +25,7 @@ namespace Module.Application.SceneSwitch
                 return;
             }
             
-            if (img.IsActive() == false)
+            if (!img.enabled)
                 img.enabled = true;
         }
 
@@ -81,14 +81,21 @@ namespace Module.Application.SceneSwitch
         /// <summary>
         /// フェード終了時にα値が 0 = フェードイン終了 
         /// </summary>
-        public bool IsFadeInComplete() => fadeState == FadeState.None && img.color.a == 0;
+        public bool IsFadeInComplete() => fadeState == FadeState.None && img.color.a < 0.01;
         public bool IsFadeOutComplete() => fadeState == FadeState.None && img.color.a >= 1;
         public bool IsFading() => fadeState != FadeState.None;
-        
+
         /// <summary>
         /// フェード中の進行率を計算する(0～1)
         /// </summary>
-        private float GetFadeProgress() => Mathf.Clamp01(timer / fadeDuration);
+        private float GetFadeProgress()
+        {
+            if (fadeDuration <= 0f) // NaN対策 0秒の時はフェードなし
+                return 1f;
+            
+            return Mathf.Clamp01(timer / fadeDuration);
+        }
+
         private void ResetTimer() => timer = 0.0f;
 
         /// <summary>
@@ -125,7 +132,7 @@ namespace Module.Application.SceneSwitch
         
         private void OnFadeOutComplete()
         {
-            SetImageProperties(1,  false);
+            SetImageProperties(1,  true);
             fadeState = FadeState.None;
         }
     }

--- a/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/ImageFader.cs
+++ b/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/ImageFader.cs
@@ -1,42 +1,32 @@
 ﻿using System.Collections;
 using UnityEngine;
+using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 namespace Module.Application.SceneSwitch
 {
     public class ImageFader : MonoBehaviour, IFadeHandler
     {
-        [Header("フェードインなし(デバッグ用)")]
-        public bool firstFadeInComp;
-
+      
         private Image img = null;
         private float timer = 0.0f;
         private FadeState fadeState = FadeState.None;
         
         private enum FadeState { None, FadingIn, FadingOut }
         [Header("フェード処理にかかる時間")]
-        [SerializeField] private  float FadeDuration = 1.0f; 
+        [SerializeField] private float fadeDuration = 1.0f; 
 
         private void Start()
         {
             img = GetComponent<Image>();
             if (img == null)
             {
-                Debug.LogError("Image Component is null");
+                Debug.LogError("ImageComponentがnullです");
                 return;
             }
             
             if (img.IsActive() == false)
                 img.enabled = true;
-
-            if (firstFadeInComp)
-            {
-                OnFadeInComplete();
-            }
-            else
-            {
-                StartCoroutine(WaitForFadeStart(0.5f));
-            }
         }
 
         private void Update()
@@ -77,12 +67,10 @@ namespace Module.Application.SceneSwitch
             {
                 // フェードイン中にフェードアウトが呼ばれた場合、
                 // 進行度を引き継いでスムーズに移行
-                timer = FadeDuration - timer;
-                Debug.Log("time = " + timer);
+                timer = fadeDuration - timer;
             }
             else
             {
-                Debug.Log("call reset Timer");
                 ResetTimer();
                 SetImageProperties(0,true);
             }
@@ -100,7 +88,7 @@ namespace Module.Application.SceneSwitch
         /// <summary>
         /// フェード中の進行率を計算する(0～1)
         /// </summary>
-        private float GetFadeProgress() => Mathf.Clamp01(timer / FadeDuration);
+        private float GetFadeProgress() => Mathf.Clamp01(timer / fadeDuration);
         private void ResetTimer() => timer = 0.0f;
 
         /// <summary>
@@ -118,13 +106,11 @@ namespace Module.Application.SceneSwitch
         /// <param name="alpha">進捗</param>
         private void UpdateFade(float alpha, System.Action onComplete)
         {
-            Debug.Log(timer);
             // α値を更新
             img.color = new Color(img.color.r, img.color.g, img.color.b, alpha);
 
-            if (timer >= FadeDuration)
+            if (timer >= fadeDuration)
             {
-                Debug.Log($"OnComplete {timer} : " + FadeDuration);
                 onComplete?.Invoke();
             }
 
@@ -141,15 +127,6 @@ namespace Module.Application.SceneSwitch
         {
             SetImageProperties(1,  false);
             fadeState = FadeState.None;
-        }
-
-        /// <summary>
-        /// フェード処理開始前に一定フレーム待機
-        /// </summary>
-        private IEnumerator WaitForFadeStart(float waitTime)
-        {
-            yield return new WaitForSeconds(waitTime);
-            StartFadeIn();
         }
     }
 }

--- a/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/ImageFader.cs
+++ b/MicroMacro/Assets/Scripts/Module/Application/SceneSwitch/ImageFader.cs
@@ -11,7 +11,7 @@ namespace Module.Application.SceneSwitch
 
         private Image img = null;
         private float timer = 0.0f;
-        private FadeState m_fadeState = FadeState.None;
+        private FadeState fadeState = FadeState.None;
         
         private enum FadeState { None, FadingIn, FadingOut }
         [Header("フェード処理にかかる時間")]
@@ -25,6 +25,9 @@ namespace Module.Application.SceneSwitch
                 Debug.LogError("Image Component is null");
                 return;
             }
+            
+            if (img.IsActive() == false)
+                img.enabled = true;
 
             if (firstFadeInComp)
             {
@@ -38,79 +41,87 @@ namespace Module.Application.SceneSwitch
 
         private void Update()
         {
-            if (m_fadeState == FadeState.FadingIn)
+            if (fadeState == FadeState.FadingIn)
             {
+                // タイマーが進むにつれα値が1から0に(透明に)
                 UpdateFade(1 - GetFadeProgress(), FadeInComplete);
             }
-            else if (m_fadeState == FadeState.FadingOut)
+            else if (fadeState == FadeState.FadingOut)
             {
+                // タイマーが進むにつれα値が0から1に(暗く)
                 UpdateFade(GetFadeProgress(), FadeOutComplete);
             }
         }
        
         public void StartFadeIn()
         {
-            if (m_fadeState != FadeState.None)
+            if (fadeState != FadeState.None)
                 return;
 
-            m_fadeState = FadeState.FadingIn;
+            fadeState = FadeState.FadingIn;
             ResetTimer();
-            SetImageProperties(1, 1, true);
+            SetImageProperties(1, true);  // 開始時は真っ黒
         }
 
         public void StartFadeOut()
         {
-            if (m_fadeState != FadeState.None)
+            // フェードアウト中or完了している場合
+            if (fadeState == FadeState.FadingOut)
                 return;
             
     #if UNITY_EDITOR
             Debug.Log("フェードアウト開始");
     #endif
 
-            m_fadeState = FadeState.FadingOut;
-            ResetTimer();
-            SetImageProperties(0,0, true);
-            
+            if (fadeState == FadeState.FadingIn)
+            {
+                // フェードイン中にフェードアウトが呼ばれた場合、
+                // 進行度を引き継いでスムーズに移行
+                timer = FadeDuration - timer;
+            }
+            else
+            {
+                ResetTimer();
+                SetImageProperties(0,true);
+            }
+
+            fadeState = FadeState.FadingOut;
         }
 
         /// <summary>
         /// フェード終了時にα値が 0 = フェードイン終了 
         /// </summary>
-        public bool IsFadeInComplete() => m_fadeState == FadeState.None && img.color.a == 0;
-
-        public bool IsFadeOutComplete() => m_fadeState == FadeState.None && img.color.a >= 1;
-
+        public bool IsFadeInComplete() => fadeState == FadeState.None && img.color.a == 0;
+        public bool IsFadeOutComplete() => fadeState == FadeState.None && img.color.a >= 1;
+        public bool IsFading() => fadeState != FadeState.None;
+        
         /// <summary>
         /// フェード中の進行率を計算する(0～1)
         /// </summary>
         private float GetFadeProgress() => Mathf.Clamp01(timer / FadeDuration);
-
         private void ResetTimer() => timer = 0.0f;
 
         /// <summary>
         /// Imageのプロパティ一括設定 徐々にalpha値変化させる
         /// </summary>
-        /// <param name="fillAmount"></param>
-        /// <param name="raycastTarget"></param>
-        private void SetImageProperties(float alpha, float fillAmount, bool raycastTarget)
+        private void SetImageProperties(float alpha, bool raycastTarget)
         {
             img.color = new Color(0, 0, 0, alpha);
-            img.fillAmount = fillAmount;
             img.raycastTarget = raycastTarget;
         }
 
         /// <summary>
         /// フェードの更新 完了したらイベント呼ぶ
         /// </summary>
-        /// <param name="progress">進捗</param>
-        /// <param name="onComplete"></param>
-        private void UpdateFade(float progress, System.Action onComplete)
+        /// <param name="alpha">進捗</param>
+        private void UpdateFade(float alpha, System.Action onComplete)
         {
-            SetImageProperties(progress, progress, true);
+            // α値を更新
+            img.color = new Color(img.color.r, img.color.g, img.color.b, alpha);
 
             if (timer >= FadeDuration)
             {
-                onComplete.Invoke();
+                onComplete?.Invoke();
             }
 
             timer += Time.deltaTime;
@@ -118,14 +129,14 @@ namespace Module.Application.SceneSwitch
    
         private void FadeInComplete()
         {
-            SetImageProperties(0, 0, false);
-            m_fadeState = FadeState.None;
+            SetImageProperties(0,  false);
+            fadeState = FadeState.None;
         }
         
         private void FadeOutComplete()
         {
-            SetImageProperties(1, 1, false);
-            m_fadeState = FadeState.None;
+            SetImageProperties(1,  false);
+            fadeState = FadeState.None;
         }
 
         /// <summary>


### PR DESCRIPTION
動作確認大体OK
各シーンにSceneManagerそのまま置くだけでOKに

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - シーンをまたいで持続するフェードUIを導入し、遷移中のフェードが一貫して適用されます。
  - 非同期の遷移フローにより、フェードアウト→シーン読み込み→フェードインが自動実行されます。

- 改善
  - フェード進行の判定を強化し、フェードイン／フェードアウトの切替が自然なクロスフェードに。
  - 初期化タイミングを早め、フェード表示の安定性を向上。

- バグ修正
  - 同一シーンへの遷移を防止するバリデーションを追加。
  - フェードUI未設定時のエラーハンドリングを改善し遷移の固着を回避。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->